### PR TITLE
fix crash on fenix6pro

### DIFF
--- a/source/State.mc
+++ b/source/State.mc
@@ -278,7 +278,7 @@ class State {
             // Workaround for Fenix5X - see #51
             maxHR = zones[zones.size() - 1];
             minHR = profile.restingHeartRate;
-            if (minHR == 0) {
+            if (minHR == null || minHR == 0) {
                 minHR = 50;
             }
         }


### PR DESCRIPTION
restingHeartRate can be null since recent API changes: https://forums.garmin.com/developer/connect-iq/i/bug-reports/getprofile-restingheartrate-return-null / https://developer.garmin.com/connect-iq/api-docs/Toybox/UserProfile/Profile.html#restingHeartRate-var